### PR TITLE
helm-do-ag now respects variable helm-ag-thing-at-point

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -289,7 +289,7 @@
   (interactive)
   (let ((helm-ag-default-directory (or basedir default-directory)))
     (helm-ag-save-current-context)
-    (helm :sources '(helm-source-do-ag) :buffer "*helm-ag*")))
+    (helm :sources '(helm-source-do-ag) :buffer "*helm-ag*" :input (helm-ag--insert-thing-at-point helm-ag-thing-at-point))))
 
 (provide 'helm-ag)
 


### PR DESCRIPTION
When helm-ag-thing-at-point is set, helm-do-ag currently does not respect the variable.
This patch changes that.
This entails that when the user has their cursor above, e.g., a symbol, and helm-ag-thing-at-point is set to symbol, the helm input buffer will be pre-populated with the symbol beneath the cursor.
