### PR TITLE
Preserve default-directory for saved results

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -726,7 +726,8 @@ Special commands:
     (helm-attrset 'name (helm-ag--helm-header helm-ag--default-directory)
                   helm-source-do-ag)
     (if (not one-directory-p)
-        (helm-do-ag--helm)
+        (let ((default-directory helm-ag--default-directory))
+          (helm-do-ag--helm))
       (let* ((helm-ag--default-directory
               (file-name-as-directory (car helm-do-ag--default-target)))
              (helm-do-ag--default-target nil))

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -512,7 +512,8 @@ Special commands:
       (setq-local helm-ag--search-this-file-p search-this-file-p)
       (setq-local helm-ag--default-directory helm-ag--default-directory)
       (helm-ag-mode)
-      (pop-to-buffer buf))
+      (pop-to-buffer buf)
+      (compilation-minor-mode))
     (message "Helm Grep Results saved in `%s' buffer" buf)))
 
 (defun helm-ag--run-save-buffer ()


### PR DESCRIPTION
When saving results, we need to capture the relative directory from
which the search was initiated from and set default-directory for that
saved buffer results.

Fixes #72