### PR TITLE
Update default-directory for each results

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -496,26 +496,26 @@ Special commands:
 \\{helm-ag-mode-map}")
 
 (defun helm-ag--save-results (_unused)
-  (let ((default-directory helm-ag--default-directory))
-    (let ((buf "*helm ag results*")
-          search-this-file-p)
-      (with-current-buffer (get-buffer-create buf)
-        (setq buffer-read-only t)
-        (let ((inhibit-read-only t))
-          (erase-buffer)
-          (insert "-*- mode: helm-ag -*-\n\n"
-                  (format "Ag Results for `%s':\n\n" helm-ag--last-query))
-          (save-excursion
-            (insert (with-current-buffer helm-buffer
-                      (goto-char (point-min))
-                      (forward-line 1)
-                      (setq search-this-file-p (helm-attr 'search-this-file))
-                      (buffer-substring (point) (point-max))))))
-        (setq-local helm-ag--search-this-file-p search-this-file-p)
-        (setq-local helm-ag--default-directory helm-ag--default-directory)
-        (helm-ag-mode)
-        (pop-to-buffer buf))
-      (message "Helm Ag Results saved in `%s' buffer" buf))))
+  (let ((buf "*helm ag results*")
+        search-this-file-p)
+    (with-current-buffer (get-buffer-create buf)
+      (setq-local default-directory helm-ag--default-directory)
+      (setq buffer-read-only t)
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "-*- mode: helm-ag -*-\n\n"
+                (format "Ag Results for `%s':\n\n" helm-ag--last-query))
+        (save-excursion
+          (insert (with-current-buffer helm-buffer
+                    (goto-char (point-min))
+                    (forward-line 1)
+                    (setq search-this-file-p (helm-attr 'search-this-file))
+                    (buffer-substring (point) (point-max))))))
+      (setq-local helm-ag--search-this-file-p search-this-file-p)
+      (setq-local helm-ag--default-directory helm-ag--default-directory)
+      (helm-ag-mode)
+      (pop-to-buffer buf))
+    (message "Helm Ag Results saved in `%s' buffer" buf)))
 
 (defun helm-ag--run-save-buffer ()
   (interactive)


### PR DESCRIPTION
Need to set `default-directory' for not only first time saved results
but also subsequent search results if the saved buffer was not killed.

Updates #94