### PR TITLE
[WIP] Implement converter which converts emacs lisp regexp to PCRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Base command of `ag`.
 
 Command line option of base command.
 
-#### `helm-ag-insert-at-point`(Default: `'nil`)
+#### `helm-ag-insert-at-point`(Default: `nil`)
 
 Insert thing at point as default search pattern, if this value is `non nil`.
 You can set the parameter same as `thing-at-point`(Such as `'word`, `symbol` etc).
@@ -128,19 +128,24 @@ If this value is `'file-line`, `helm-ag` displays candidate as helm `file-line` 
 
 ![helm-ag-file-line](image/helm-ag-file-line.png)
 
-#### `helm-ag-use-grep-ignore-list`(Default: `'nil`)
+#### `helm-ag-use-grep-ignore-list`(Default: `nil`)
 
 Use `grep-find-ignored-files` and `grep-find-ignored-directories` as ignore pattern.
 They are specified to `--ignore' options."
 
-#### `helm-ag-always-set-extra-option`(Default: `'nil`)
+#### `helm-ag-always-set-extra-option`(Default: `nil`)
 
 Always set extra command line option of `ag` in `helm-do-ag`
 if this value is non-nil.
 
-#### `helm-ag-edit-save`(Default: `'t`)
+#### `helm-ag-edit-save`(Default: `t`)
 
 Save buffers you edit at editing completed.
+
+#### `helm-ag-use-emacs-lisp-regexp`(Default: `nil`)
+
+Use Emacs Lisp regexp instead of PCRE as pattern.
+NOTE: this is very simple convertion.
 
 
 ## Keymap

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -89,6 +89,11 @@ They are specified to `--ignore' options."
   :type 'boolean
   :group 'helm-ag)
 
+(defcustom helm-ag-use-emacs-lisp-regexp nil
+  "[Experimental] Use Emacs Lisp regexp instead of PCRE."
+  :type 'boolean
+  :group 'helm-ag)
+
 (defvar helm-ag--command-history '())
 (defvar helm-ag--context-stack nil)
 (defvar helm-ag--default-directory nil)
@@ -344,6 +349,8 @@ They are specified to `--ignore' options."
          (query (read-string "Pattern: " searched-word 'helm-ag--command-history)))
     (when (string= query "")
       (error "Input is empty!!"))
+    (when helm-ag-use-emacs-lisp-regexp
+      (setq query (helm-ag--elisp-regexp-to-pcre query)))
     (setq helm-ag--last-query query
           helm-ag--elisp-regexp-query (helm-ag--pcre-to-elisp-regexp query))
     (setq helm-ag--valid-regexp-for-emacs

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -239,6 +239,20 @@ They are specified to `--ignore' options."
       (forward-char 1))
     (buffer-string)))
 
+(defun helm-ag--elisp-regexp-to-pcre (regexp)
+  (with-temp-buffer
+    (insert regexp)
+    (goto-char (point-min))
+    (while (re-search-forward "[(){}|]" nil t)
+      (backward-char 1)
+      (cond ((looking-back "\\\\\\\\"))
+            ((looking-back "\\\\")
+             (delete-char -1))
+            (t
+             (insert "\\")))
+      (forward-char 1))
+    (buffer-string)))
+
 (defun helm-ag--highlight-candidate (candidate)
   (let ((limit (1- (length candidate)))
         (last-pos 0))

--- a/test/test-util.el
+++ b/test/test-util.el
@@ -145,4 +145,20 @@
   (let ((got (helm-ag--pcre-to-elisp-regexp "\\\\(foo\\\\|bar\\\\)")))
     (should (string= got "\\\\(foo\\\\|bar\\\\)"))))
 
+(ert-deftest emacs-lisp-regexp-to-pcre ()
+  "Simple convertion from Emacs lisp regexp to PCRE"
+  (let ((got (helm-ag--elisp-regexp-to-pcre "\\(foo\\|bar\\)")))
+    (should (string= got "(foo|bar)")))
+  (let ((got (helm-ag--elisp-regexp-to-pcre "foo\\{1,2\\}")))
+    (should (string= got "foo{1,2}")))
+
+  (let ((got (helm-ag--elisp-regexp-to-pcre "(foo|bar)")))
+    (should (string= got "\\(foo\\|bar\\)")))
+
+  (let ((got (helm-ag--elisp-regexp-to-pcre "foo{1,2}")))
+    (should (string= got "foo\\{1,2\\}")))
+
+  (let ((got (helm-ag--elisp-regexp-to-pcre "\\\\(foo\\\\|bar\\\\)")))
+    (should (string= got "\\\\(foo\\\\|bar\\\\)"))))
+
 ;;; test-util.el ends here


### PR DESCRIPTION
`ag` can take PCRE as pattern, while helm can take Emacs Lisp regexp.
This is confusing. So I implement simple converter Emacs Lisp regexp -> PCRE.
We can use Emacs Lisp regexp as pattern with this patch.