### PR TITLE
Fix for Windows pt

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -743,6 +743,9 @@ Special commands:
   (when (helm-ag--has-c-u-preffix-p)
     (helm-grep-get-file-extensions helm-do-ag--default-target)))
 
+(defsubst helm-ag--windows-p ()
+  (memq system-type '(ms-dos windows-nt)))
+
 (defsubst helm-do-ag--is-target-one-directory-p (targets)
   (and (listp targets) (= (length targets) 1) (file-directory-p (car targets))))
 
@@ -771,7 +774,7 @@ Special commands:
     (helm-ag--save-current-context)
     (helm-attrset 'name (helm-ag--helm-header helm-ag--default-directory)
                   helm-source-do-ag)
-    (if (not one-directory-p)
+    (if (or (helm-ag--windows-p) (not one-directory-p)) ;; Path argument must be specified on Windows
         (helm-do-ag--helm)
       (let* ((helm-ag--default-directory
               (file-name-as-directory (car helm-do-ag--default-target)))


### PR DESCRIPTION
This is related to #99.

'pt' process is killed just after 'start-process' if path arguments
are not specified on Windows.

I confirmed that `helm-do-ag` works well on Window.
