### PR TITLE
Better highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 * helm 1.5.6 or higher
 * [The Silver Searcher](https://github.com/ggreer/the_silver_searcher) 0.25 or higher.
 
-I suppose you can use older version ag however if you want to use all features of helm-ag, please upgrade ag version.
+You may be able to use older version ag however I recommend you to use newer ag for using all features of `helm-ag`.
 
 ## Installation
 

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -123,9 +123,26 @@ They are specified to `--ignore' options."
 (defvar helm-ag--ignore-case nil)
 (defvar helm-do-ag--extensions nil)
 
-(defsubst helm-ag--ignore-case-p (cmds)
-  (cl-loop for opt in '("-i" "--ignore-case")
+(defsubst helm-ag--has-anzu--case-fold-search (input)
+  (let ((case-fold-search nil))
+    (not (string-match-p "[A-Z]" input))))
+
+(defsubst helm-ag--has-options (cmds options)
+  (cl-loop for opt in options
            thereis (member opt cmds)))
+
+(defsubst helm-ag--has-case-sensitive-option (cmds)
+  (helm-ag--has-options cmds '("-s" "--case-sensitive")))
+
+(defsubst helm-ag--has-case-ignore-option (cmds)
+  (helm-ag--has-options cmds '("-i" "--ignore-case")))
+
+(defun helm-ag--ignore-case-p (cmds input)
+  (cond ((helm-ag--has-case-sensitive-option cmds) nil)
+        ((helm-ag--has-case-ignore-option cmds) t)
+        (t
+         (let ((case-fold-search nil))
+           (not (string-match-p "[A-Z]" input))))))
 
 (defun helm-ag--save-current-context ()
   (let ((curpoint (with-helm-current-buffer
@@ -226,7 +243,7 @@ They are specified to `--ignore' options."
              (cmds (helm-ag--construct-command (helm-attr 'search-this-file)))
              (coding-system-for-read buf-coding)
              (coding-system-for-write buf-coding))
-        (setq helm-ag--ignore-case (helm-ag--ignore-case-p cmds))
+        (setq helm-ag--ignore-case (helm-ag--ignore-case-p cmds helm-ag--last-query))
         (let ((ret (apply 'process-file (car cmds) nil t nil (cdr cmds))))
           (if (zerop (length (buffer-string)))
               (error "No output: '%s'" helm-ag--last-query)
@@ -735,7 +752,7 @@ Continue searching the parent directory? "))
   (let* ((default-directory (or helm-ag--default-directory default-directory))
          (cmd-args (helm-ag--construct-do-ag-command helm-pattern))
          (proc (apply 'start-file-process "helm-do-ag" nil cmd-args)))
-    (setq helm-ag--ignore-case (helm-ag--ignore-case-p cmd-args))
+    (setq helm-ag--ignore-case (helm-ag--ignore-case-p cmd-args helm-pattern))
     (prog1 proc
       (set-process-sentinel
        proc

--- a/test/test-util.el
+++ b/test/test-util.el
@@ -192,4 +192,13 @@
   (let ((got (helm-ag--elisp-regexp-to-pcre "\\\\(foo\\\\|bar\\\\)")))
     (should (string= got "\\\\(foo\\\\|bar\\\\)"))))
 
+(ert-deftest judge-ignore-case ()
+  "Judge ignore case searching or not "
+  (should (helm-ag--ignore-case-p nil "aa"))
+  (should (not (helm-ag--ignore-case-p nil "AA")))
+  (should (helm-ag--ignore-case-p '("-i") "AA"))
+  (should (helm-ag--ignore-case-p '("--ignore-case") "Apple"))
+  (should (not (helm-ag--ignore-case-p '("-s") "apple")))
+  (should (not (helm-ag--ignore-case-p '("--case-sensitive") "apple"))))
+
 ;;; test-util.el ends here


### PR DESCRIPTION
Because `ag` uses smartcase matching as default.