### PR TITLE
Don't ask searched extensions when basedir is defined

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -853,7 +853,8 @@ Continue searching the parent directory? "))
                                             "Search in file(s): "
                                             :default default-directory
                                             :marked-candidates t :must-match t)))))
-         (helm-do-ag--extensions (helm-ag--do-ag-searched-extensions))
+         (helm-do-ag--extensions (when (and helm-ag--default-target (not basedir))
+                                   (helm-ag--do-ag-searched-extensions)))
          (one-directory-p (helm-do-ag--is-target-one-directory-p
                            helm-ag--default-target)))
     (helm-ag--set-do-ag-option)


### PR DESCRIPTION
Related issue
- https://github.com/bbatsov/projectile/issues/819
