### PR TITLE
helm-do-ag: Allow C-u with a provided basedir

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -898,7 +898,7 @@ Continue searching the parent directory? "))
                                             "Search in file(s): "
                                             :default default-directory
                                             :marked-candidates t :must-match t)))))
-         (helm-do-ag--extensions (when (and helm-ag--default-target (not basedir))
+         (helm-do-ag--extensions (when helm-ag--default-target
                                    (helm-ag--do-ag-searched-extensions)))
          (one-directory-p (helm-do-ag--target-one-directory-p
                            helm-ag--default-target)))


### PR DESCRIPTION
Hi Syohei,

This PR allows to use `C-u` even when `basedir` is specified. I tested it and it seems to work but there might be a reason why this test was in place.

Cheers,
syl20bnr