### PR TITLE
Support dynamic filename filter for helm-do-ag

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -751,7 +751,7 @@ Continue searching the parent directory? "))
   (if helm-do-ag--allow-filename-filter
       (let (files patterns)
         (mapc (lambda (item)
-                (if (string-match-p "\\`\!" item)
+                (if (string-match-p "\\`\!." item)
                     (push (substring item 1) files)
                   (push item patterns)))
               (split-string pattern " "))


### PR DESCRIPTION
I don't know if you will like this idea, but I thought it was convenient to have as an option. Thanks for the great project!

The idea is to parse a pattern like "asdf !el jkl !txt" so that the ag
command becomes -Gel|txt asdf jkl. The ! terms are added to the -G
argument dynamically, so that if you are in the middle of a search with
a lot of results you can quickly narrow by filename without starting
over by just adding ! terms.

The feature is off by default and controlled by the variable
`helm-do-ag--allow-filename-filter`.