### PR TITLE
Add list support to this-file for helm-do-ag

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -899,7 +899,10 @@ Continue searching the parent directory? "))
   (setq helm-ag--original-window (selected-window))
   (helm-ag--clear-variables)
   (let* ((helm-ag--default-directory (or basedir default-directory))
-         (helm-ag--default-target (cond (this-file (list this-file))
+         (helm-ag--default-target (cond (this-file (cond ((listp this-file)
+                                                          this-file)
+                                                         (t
+                                                          (list this-file))))
                                         ((and (helm-ag--windows-p) basedir) (list basedir))
                                         (t
                                          (when (and (not basedir) (not helm-ag--buffer-search))


### PR DESCRIPTION
Add list support to this-file for helm-do-ag, to support building command line like:
ag pattern location1 location2...

It's required for making helm-projectile-ag to respect .projectile whitelist.
See https://github.com/starain/emacs-config/commit/8db9cce