### PR TITLE
Change default option for Windows

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -50,7 +50,7 @@
 
 (defcustom helm-ag-base-command
   (if (helm-ag--windows-p)
-      "ag --nocolor --nogroup --line-numbers"
+      "ag --vimgrep"
     "ag --nocolor --nogroup")
   "Base command of `ag'"
   :type 'string


### PR DESCRIPTION
helm-do-ag does not work on Windows because file names and line numbers
are not displayed. We can avoid this issue by '--vimgrep' option.