### PR TITLE
Fix for older Emacs

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -292,7 +292,7 @@ They are specified to `--ignore' options."
   (insert-file-contents filename)
   (let ((buffer-file-name filename))
     (set-auto-mode)
-    (font-lock-ensure)))
+    (font-lock-fontify-buffer)))
 
 (defun helm-ag--persistent-action (candidate)
   (let ((find-func (if helm-ag-use-temp-buffer


### PR DESCRIPTION
font-lock-ensure is defined only development version.