### PR TITLE
Convert '!pattern' into invert match patter

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -734,14 +734,22 @@ Continue searching the parent directory? "))
       (push (buffer-substring-no-properties prev (point)) patterns)
       (reverse (cl-loop for p in patterns unless (string= p "") collect p)))))
 
+(defsubst helm-ag--convert-invert-pattern (pattern)
+  (if (and (not helm-ag--command-feature)
+           (string-prefix-p "!" pattern) (> (length pattern) 1))
+      (concat "^(?!.*" (substring pattern 1) ").+$")
+    pattern))
+
 (defun helm-ag--join-patterns (input)
   (let ((patterns (helm-ag--split-string input)))
     (if (= (length patterns) 1)
-        (car patterns)
+        (helm-ag--convert-invert-pattern (car patterns))
       (cl-case helm-ag--command-feature
         (pt input)
         (pt-regexp (mapconcat 'identity patterns ".*"))
-        (otherwise (mapconcat (lambda (s) (concat "(?=.*" s ".*)")) patterns ""))))))
+        (otherwise (cl-loop for s in patterns
+                            for p = (helm-ag--convert-invert-pattern s)
+                            concat (concat "(?=.*" p ".*)")))))))
 
 (defun helm-ag--do-ag-highlight-patterns (input)
   (if helm-ag--command-feature


### PR DESCRIPTION
We can input invert match pattern in PCRE like '^(?!.*pattern).+$'.
However it is difficult to type it. And this conversion is same as
normal helm command so that I suppose it is useful for helm users.

![helm-ag2](https://cloud.githubusercontent.com/assets/554281/11449626/23d16c20-95c0-11e5-8309-7ea6dc226c0c.gif)


This is related to #187.
CC: @mpollmeier