### PR TITLE
add live previewing to results

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -117,6 +117,21 @@ They are specified to `--ignore' options."
   "Face of deleted line in edit mode."
   :group 'helm-ag)
 
+(defface helm-ag-preview-line
+  '((t (:background "green" :foreground "black")))
+  "Face of preview line."
+  :group 'helm-ag)
+
+(defface helm-ag-process-pattern-match
+  '((t (:background "purple" :foreground "white")))
+  "Face of the text matched by the pattern given to the ag process."
+  :group 'helm-ag)
+
+(defface helm-ag-minibuffer-match
+  '((t (:background "blue" :foreground "yellow")))
+  "Face of the text matched for the pattern given in the minibuffer."
+  :group 'helm-ag)
+
 (defvar helm-ag--command-history '())
 (defvar helm-ag--context-stack nil)
 (defvar helm-ag--default-directory nil)

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -272,12 +272,14 @@ They are specified to `--ignore' options."
               helm-ag--last-command cmds)
         (let ((ret (apply 'process-file (car cmds) nil t nil (cdr cmds))))
           (if (zerop (length (buffer-string)))
-              (error "No output: '%s'" helm-ag--last-query)
+              (error "No ag output: '%s'" helm-ag--last-query)
             (unless (zerop ret)
               (unless (executable-find (car cmds))
                 (error "'ag' is not installed."))
               (error "Failed: '%s'" helm-ag--last-query))))
         (helm-ag--save-current-context)))))
+
+(add-to-list 'debug-ignored-errors "^No ag output: ")
 
 (defun helm-ag--search-only-one-file-p ()
   (when (and helm-ag--default-target (= (length helm-ag--default-target) 1))

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1023,7 +1023,6 @@ buffer as `helm-ag' highlights their matches.")
           (end (1+ (line-end-position))))
       (move-overlay olay beg end buf))))
 
-;;; temporary variables used as
 (defvar helm-ag--previous-preview-buffer nil
   "Sentinel used in `helm-ag--display-preview' to tell whether the match has
 changed.")

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -294,14 +294,12 @@ large buffers."
               helm-ag--last-command cmds)
         (let ((ret (apply 'process-file (car cmds) nil t nil (cdr cmds))))
           (if (zerop (length (buffer-string)))
-              (error "No ag output: '%s'" helm-ag--last-query)
+              (error "No output: '%s'" helm-ag--last-query)
             (unless (zerop ret)
               (unless (executable-find (car cmds))
                 (error "'ag' is not installed."))
               (error "Failed: '%s'" helm-ag--last-query))))
         (helm-ag--save-current-context)))))
-
-(add-to-list 'debug-ignored-errors "^No ag output: ")
 
 (defun helm-ag--search-only-one-file-p ()
   (when (and helm-ag--default-target (= (length helm-ag--default-target) 1))

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -963,7 +963,7 @@ search."
   (helm-ag--clean-add-overlays beg end primary-regexp primary-face
                                secondary-regexp secondary-face))
 
-(defun helm-ag--refresh-overlays-for-buffer (beg end)
+(defun helm-ag--refresh-overlays-in-region (beg end)
   (setq helm-ag--process-preview-overlays
         (helm-ag--refresh-overlay-list
          helm-ag--process-preview-overlays beg end
@@ -973,7 +973,7 @@ search."
 
 (defun helm-ag--refresh-listing-overlays ()
   (with-helm-window
-    (helm-ag--refresh-overlays-for-buffer (point-min) (point-max))))
+    (helm-ag--refresh-overlays-in-region (point-min) (point-max))))
 
 (defvar helm-ag--preview-overlay nil)
 (defvar-local helm-ag--process-preview-overlays nil)
@@ -1008,7 +1008,7 @@ search."
                          (string-equal helm-ag--previous-minibuffer-pattern
                                        helm-pattern))
               ;; maybe add with-current-buffer if this doesn't work?
-              (helm-ag--refresh-overlays-for-buffer
+              (helm-ag--refresh-overlays-in-region
                ;; (line-beginning-position) (line-end-position)
                (point-min) (point-max)))
             (helm-ag--recenter))


### PR DESCRIPTION
This pull request adds live previewing capabilities to the result matches, so that you can see each match just by moving point over it, without having to press tab. In addition, this adds the ability to highlight the line and text matched on each line which ag matches. The defcustom `helm-ag--preview-highlight-changes`, if set to `nil`, has the same behavior as before these commits. If set to `'any`, you see the text matched by the ag search highlighted throughout the target buffers, and also the text matched by the helm search among the candidates returned by the ag search.

This is a big pull request and I've spent a good amount of time debugging it, but there could still be issues. Please tell me if I can change anything to make this more useful.