### PR TITLE
don't try to debug errors caused by no ag output

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -257,12 +257,14 @@ They are specified to `--ignore' options."
               helm-ag--last-command cmds)
         (let ((ret (apply 'process-file (car cmds) nil t nil (cdr cmds))))
           (if (zerop (length (buffer-string)))
-              (error "No output: '%s'" helm-ag--last-query)
+              (error "No ag output: '%s'" helm-ag--last-query)
             (unless (zerop ret)
               (unless (executable-find (car cmds))
                 (error "'ag' is not installed."))
               (error "Failed: '%s'" helm-ag--last-query))))
         (helm-ag--save-current-context)))))
+
+(add-to-list 'debug-ignored-errors "^No ag output: ")
 
 (defun helm-ag--search-only-one-file-p ()
   (when (and helm-ag--default-target (= (length helm-ag--default-target) 1))


### PR DESCRIPTION
`ag` sometimes doesn't have any output, if there are no hits for the given regular expression. I have `debug-on-error` set to t sometimes and don't like going to `*backtrace*`, since this isn't really an error. This turns that off.