### PR TITLE
move to next file functionality

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -710,8 +710,8 @@ Special commands:
 
 (defun helm-ag--refresh-position ()
   (let ((helm-swoop-move-to-line-cycle t))
-    (helm-move-selection-common :where 'line :direction 'next)
-    (helm-move-selection-common :where 'line :direction 'previous)))
+    (call-interactively #'helm-next-line)
+    (call-interactively #'helm-previous-line)))
 
 (defun helm-ag--next-file ()
   (interactive)

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -687,6 +687,7 @@ Special commands:
   (with-helm-window
     (let ((initial-match-info (helm-ag--get-match-info))
           (helm-move-to-line-cycle-in-source t))
+      ;; if there are any matches
       (when initial-match-info
         (cl-destructuring-bind (:file file :line line) initial-match-info
           (helm-move-selection-common :where 'line :direction direction)


### PR DESCRIPTION
moves to the previous/next file in the list of matches, or messages the user saying there's only file in all the list of matches. there are possible speed issues with large numbers of matches (even 100 matches is noticeably slow), but <kbd>C-g</kbd> stops it just fine.