### PR TITLE
Refactoring code

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -49,9 +49,6 @@
 (defsubst helm-ag--windows-p ()
   (memq system-type '(ms-dos windows-nt)))
 
-(defsubst helm-ag--has-drive-letter-p (path)
-  (string-match-p "\\`[a-zA-Z]:" path))
-
 (defcustom helm-ag-base-command
   (if (helm-ag--windows-p)
       "ag --vimgrep"

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -243,7 +243,7 @@ They are specified to `--ignore' options."
              (coding-system-for-write buf-coding))
         (setq helm-ag--ignore-case (helm-ag--ignore-case-p cmds helm-ag--last-query)
               helm-ag--last-command cmds)
-        (let ((ret (apply 'process-file (car cmds) nil t nil (cdr cmds))))
+        (let ((ret (apply #'process-file (car cmds) nil t nil (cdr cmds))))
           (if (zerop (length (buffer-string)))
               (error "No ag output: '%s'" helm-ag--last-query)
             (unless (zerop ret)
@@ -287,8 +287,8 @@ They are specified to `--ignore' options."
 
 (defun helm-ag--persistent-action (candidate)
   (let ((find-func (if helm-ag-use-temp-buffer
-                       'helm-ag--open-file-with-temp-buffer
-                     'find-file)))
+                       #'helm-ag--open-file-with-temp-buffer
+                     #'find-file)))
     (helm-ag--find-file-action candidate find-func (helm-attr 'search-this-file) t)
     (helm-highlight-current-line)))
 
@@ -867,7 +867,7 @@ Continue searching the parent directory? "))
                                 default-directory))
          (cmd-args (helm-ag--construct-do-ag-command helm-pattern)))
     (when cmd-args
-      (let ((proc (apply 'start-file-process "helm-do-ag" nil cmd-args)))
+      (let ((proc (apply #'start-file-process "helm-do-ag" nil cmd-args)))
         (setq helm-ag--last-query helm-pattern
               helm-ag--last-command cmd-args
               helm-ag--ignore-case (helm-ag--ignore-case-p cmd-args helm-pattern)

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -57,65 +57,53 @@
       "ag --vimgrep"
     "ag --nocolor --nogroup")
   "Base command of `ag'"
-  :type 'string
-  :group 'helm-ag)
+  :type 'string)
 
 (defcustom helm-ag-command-option nil
   "Command line option of `ag'. This is appended after `helm-ag-base-command'"
-  :type 'string
-  :group 'helm-ag)
+  :type 'string)
 
 (defcustom helm-ag-insert-at-point nil
   "Insert thing at point as search pattern.
    You can set value same as `thing-at-point'"
-  :type 'symbol
-  :group 'helm-ag)
+  :type 'symbol)
 
 (defcustom helm-ag-ignore-patterns nil
   "Ignore patterns for `ag'. This parameters are specified as --ignore"
-  :type '(repeat string)
-  :group 'helm-ag)
+  :type '(repeat string))
 
 (defcustom helm-ag-use-grep-ignore-list nil
   "Use `grep-find-ignored-files' and `grep-find-ignored-directories' as ignore pattern.
 They are specified to `--ignore' options."
-  :type 'boolean
-  :group 'helm-ag)
+  :type 'boolean)
 
 (defcustom helm-ag-always-set-extra-option nil
   "Always set `ag' options of `helm-do-ag'."
-  :type 'boolean
-  :group 'helm-ag)
+  :type 'boolean)
 
 (defcustom helm-ag-fuzzy-match nil
   "Enable fuzzy match"
-  :type 'boolean
-  :group 'helm-ag)
+  :type 'boolean)
 
 (defcustom helm-ag-edit-save t
   "Save buffers you edit at completed."
-  :type 'boolean
-  :group 'helm-ag)
+  :type 'boolean)
 
 (defcustom helm-ag-use-emacs-lisp-regexp nil
   "[Experimental] Use Emacs Lisp regexp instead of PCRE."
-  :type 'boolean
-  :group 'helm-ag)
+  :type 'boolean)
 
 (defcustom helm-ag-use-agignore nil
   "Use .agignore where is at project root if it exists."
-  :type 'boolean
-  :group 'helm-ag)
+  :type 'boolean)
 
 (defcustom helm-ag-use-temp-buffer nil
   "Use temporary buffer for persistent action."
-  :type 'boolean
-  :group 'helm-ag)
+  :type 'boolean)
 
 (defface helm-ag-edit-deleted-line
   '((t (:inherit font-lock-comment-face :strike-through t)))
-  "Face of deleted line in edit mode."
-  :group 'helm-ag)
+  "Face of deleted line in edit mode.")
 
 (defvar helm-ag--command-history '())
 (defvar helm-ag--context-stack nil)


### PR DESCRIPTION
- Remove unused function
- Remove needless attribute
- Use `#'` instead of `'` for detecting typo