### PR TITLE
Use helm-ag-ignore-patterns for helm-do-ag

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -854,6 +854,11 @@ Continue searching the parent directory? "))
       (setq cmd-opts (append cmd-opts (split-string helm-ag-command-option nil t))))
     (when helm-ag--extra-options
       (setq cmd-opts (append cmd-opts (split-string helm-ag--extra-options))))
+    (when helm-ag-ignore-patterns
+          (setq cmd-opts
+                (append cmd-opts
+                        (mapcar 'helm-ag--construct-ignore-option
+                                helm-ag-ignore-patterns))))
     (when helm-ag-use-agignore
       (helm-aif (helm-ag--root-agignore)
           (setq cmd-opts (append cmd-opts (list "-p" it)))))


### PR DESCRIPTION
When using helm-do-ag, helm-ag-ignore-patterns were ignored. This fix adds them to the command.