### PR TITLE
[Workaround] Set keymap at runtime for #253

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -429,7 +429,6 @@ Default behaviour shows finish and result in mode-line."
     :fuzzy-match helm-ag-fuzzy-match
     :action helm-ag--actions
     :candidate-number-limit 9999
-    :keymap helm-ag-map
     :follow (and helm-follow-mode-persistent 1)))
 
 ;;;###autoload
@@ -767,7 +766,7 @@ Continue searching the parent directory? "))
                   (helm-ag--default-directory parent))
              (setq helm-ag--last-default-directory default-directory)
              (helm-attrset 'name (helm-ag--helm-header default-directory) helm-ag-source)
-             (helm :sources '(helm-ag-source) :buffer "*helm-ag*")))))
+             (helm :sources '(helm-ag-source) :buffer "*helm-ag*" :keymap helm-ag-map)))))
     (message nil)))
 
 ;;;###autoload
@@ -781,7 +780,7 @@ Continue searching the parent directory? "))
     (helm-attrset 'search-this-file (file-relative-name (buffer-file-name))
                   helm-ag-source)
     (helm-attrset 'name (format "Search at %s" filename) helm-ag-source)
-    (helm :sources '(helm-ag-source) :buffer "*helm-ag*")))
+    (helm :sources '(helm-ag-source) :buffer "*helm-ag*" :keymap helm-ag-map)))
 
 ;;;###autoload
 (defun helm-ag (&optional basedir)
@@ -797,7 +796,7 @@ Continue searching the parent directory? "))
       (helm-ag--query)
       (helm-attrset 'search-this-file nil helm-ag-source)
       (helm-attrset 'name (helm-ag--helm-header helm-ag--default-directory) helm-ag-source)
-      (helm :sources '(helm-ag-source) :buffer "*helm-ag*"))))
+      (helm :sources '(helm-ag-source) :buffer "*helm-ag*" :keymap helm-ag-map))))
 
 (defun helm-ag--split-string (str)
   (with-temp-buffer
@@ -996,8 +995,7 @@ Continue searching the parent directory? "))
     :nohighlight t
     :requires-pattern 3
     :candidate-number-limit 9999
-    :follow (and helm-follow-mode-persistent 1)
-    :keymap helm-do-ag-map))
+    :follow (and helm-follow-mode-persistent 1)))
 
 (defun helm-ag--do-ag-up-one-level ()
   (interactive)
@@ -1014,7 +1012,7 @@ Continue searching the parent directory? "))
              (helm-attrset 'name (helm-ag--helm-header parent)
                            helm-source-do-ag)
              (helm :sources '(helm-source-do-ag) :buffer "*helm-ag*"
-                   :input initial-input)))))
+                   :keymap helm-do-ag-map :input initial-input)))))
     (message nil)))
 
 (defun helm-ag--set-do-ag-option ()
@@ -1046,7 +1044,7 @@ Continue searching the parent directory? "))
                         helm-ag--default-directory))))
     (helm-attrset 'name (helm-ag--helm-header search-dir)
                   helm-source-do-ag)
-    (helm :sources '(helm-source-do-ag) :buffer "*helm-ag*"
+    (helm :sources '(helm-source-do-ag) :buffer "*helm-ag*" :keymap helm-do-ag-map
           :input (or (helm-ag--marked-input)
                      (helm-ag--insert-thing-at-point helm-ag-insert-at-point)))))
 


### PR DESCRIPTION
If keymap is set at compile time, keymap is not available if user does not
input anything.

This is related to #253.
CC: @yuandaxing