### PR TITLE
Fixes project root discovery in git worktrees

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1107,7 +1107,7 @@ Continue searching the parent directory? "))
         (helm-do-ag--helm)))))
 
 (defun helm-ag--project-root ()
-  (cl-loop for dir in '(".git/" ".hg/" ".svn/")
+  (cl-loop for dir in '(".git/" ".hg/" ".svn/" ".git")
            when (locate-dominating-file default-directory dir)
            return it))
 


### PR DESCRIPTION
helm-ag is not capable to find a project root for files in git-worktree. It looks for a .git directory but in a worktree there is a .git file.