### PR TITLE
Remove "--" from helm-ag--construct-do-ag-command

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -930,7 +930,7 @@ Continue searching the parent directory? "))
     (unless (string= query "")
       (append (car helm-do-ag--commands)
               (cl-remove-if (lambda (x) (string= "--" x)) options)
-              (list "--" (helm-ag--join-patterns query))
+              (list (helm-ag--join-patterns query))
               (cdr helm-do-ag--commands)))))
 
 (defun helm-ag--do-ag-set-command ()

--- a/test/test-util.el
+++ b/test/test-util.el
@@ -107,35 +107,35 @@
   (let ((helm-ag-base-command "ag --nocolor --nogroup"))
     (helm-ag--do-ag-set-command)
     (let ((got (helm-ag--construct-do-ag-command "somepattern"))
-          (expected '("ag" "--nocolor" "--nogroup" "--" "somepattern")))
+          (expected '("ag" "--nocolor" "--nogroup" "somepattern")))
       (should (equal got expected)))
 
     (let ((got (helm-ag--construct-do-ag-command "pat1 pat2"))
-          (expected '("ag" "--nocolor" "--nogroup" "--" "(?=.*pat1.*)(?=.*pat2.*)")))
+          (expected '("ag" "--nocolor" "--nogroup" "(?=.*pat1.*)(?=.*pat2.*)")))
       (should (equal got expected)))
 
     (let* ((helm-ag--command-feature 'pt)
            (got (helm-ag--construct-do-ag-command "pat1 pat2"))
-           (expected '("ag" "--nocolor" "--nogroup" "--" "pat1 pat2")))
+           (expected '("ag" "--nocolor" "--nogroup" "pat1 pat2")))
       (should (equal got expected)))
 
     (let* ((helm-ag--command-feature 'pt-regexp)
            (got (helm-ag--construct-do-ag-command "pat1 pat2"))
-           (expected '("ag" "--nocolor" "--nogroup" "--" "pat1.*pat2")))
+           (expected '("ag" "--nocolor" "--nogroup" "pat1.*pat2")))
       (should (equal got expected)))
 
     (let ((helm-ag-command-option "--ignore-case --all-text"))
       (helm-ag--do-ag-set-command)
       (let* ((got (helm-ag--construct-do-ag-command "somepattern"))
              (expected '("ag" "--nocolor" "--nogroup" "--ignore-case" "--all-text"
-                         "--" "somepattern")))
+                         "somepattern")))
         (should (equal got expected))))
 
     (let ((helm-ag-ignore-patterns '("apple" "orange")))
       (helm-ag--do-ag-set-command)
       (let* ((got (helm-ag--construct-do-ag-command "somepattern"))
              (expected '("ag" "--nocolor" "--nogroup" "--ignore=apple" "--ignore=orange"
-                         "--" "somepattern")))
+                         "somepattern")))
         (should (equal got expected))))))
 
 (ert-deftest construct-do-ag-command-with-extra-option ()
@@ -144,7 +144,7 @@
         (helm-ag--extra-options "-G\\.md$"))
     (helm-ag--do-ag-set-command)
     (let ((got (helm-ag--construct-do-ag-command "somepattern"))
-          (expected '("ag" "--nocolor" "--nogroup" "-G\\.md$" "--" "somepattern")))
+          (expected '("ag" "--nocolor" "--nogroup" "-G\\.md$" "somepattern")))
       (should (equal got expected)))))
 
 (ert-deftest validate-regexp-with-valid-regexp ()


### PR DESCRIPTION
This extra `"--"` breaks the functionality of the `-g` flag which allows ag to search file names (rather than the contents of the file).

Before this change, commands (like those which come from `helm-projectile-ag`) create lists such that observation of `helm-ag--last-command` resembles the following:

    ... "--ignore" "_darcs" "--ignore" "{arch}" "-g" "--" "test")

With this, ag returns an error. However, without the additional list item `"--"`, the command executes as follows, returning all files with names matching the pattern "test". Since this item doesn't appear to serve any additional purpose, I propose removing it (thereby restoring the functionality of `-g`)