### PR TITLE
Turn whitespaces into regular expression when taking marked input

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -476,8 +476,10 @@ Default behaviour shows finish and result in mode-line."
 
 (defsubst helm-ag--marked-input ()
   (when (use-region-p)
-    (prog1 (buffer-substring-no-properties (region-beginning) (region-end))
-      (deactivate-mark))))
+    (let* ((text (buffer-substring-no-properties (region-beginning) (region-end)))
+           (text (replace-regexp-in-string " " "\\\\ " text)))
+      (deactivate-mark)
+      text)))
 
 (defun helm-ag--query ()
   (let* ((searched-word (helm-ag--searched-word))


### PR DESCRIPTION
Hi,

When performing `helm-do-ag` on a region, I encountered a problem that this function doesn't search for the precise text in the region, but instead searches for each word in the text.

For example, if I mark the phase `foo bar` in the editor, and call `helm-do-ag`, this function will search for lines containing either `foo` or `bar`. 

Since the expected input of `helm-do-ag` should be `foo\ bar`, I have made a small modification fo the function `helm-ag--marked-input` to insert the `\` character before each space ` `, to automatically convert `foo bar` into `foo\ bar`, so that `helm-do-ag` can search for the precise phrase `foo bar`.

How do you think about this patch?

I have tested with the other function `helm-ag` and see no side-effect.