### PR TITLE
add support for rg patterns with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,13 +276,13 @@ I think the searching tool which supports grep like output, helm-ag can work wit
  '(helm-ag-base-command "rg --vimgrep --no-heading"))
 ```
 
-#### NOTE: For pt users
+#### NOTE: For pt and rg users
 
-Case using `ag` or `ack`, `helm-do-ag` convert pattern from `foo bar` to `"(?=.*" foo ".*)(?=.*" bar ".*)"`
-which patterns matches line which contains both `foo` and `bar`. But case using `pt`, `helm-do-ag`
-does not convert because Golang `regexp`(`pt` is written in Golang) does not support look-a-head pattern.
-So using `pt` behaviors is different from `ag` when you use such pattern. I suppose there is same problem
-if you use search programs which are written in Golang.
+When using `ag` or `ack`, `helm-do-ag` convert pattern from `foo bar` to `"(?=.*" foo ".*)(?=.*" bar ".*)"`
+which pattern matches line which contains both `foo` and `bar`. But when using `pt` or `rg`, `helm-do-ag`
+does not convert the pattern because Golang `regexp`(`pt` is written in Golang)
+and rust's `regex` (`regex` is written in rust) does not support look-a-head pattern.
+So using `pt` or `rg` behaves differently from `ag` when you use such pattern.
 
 ## Alternatives
 

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -1065,7 +1065,7 @@ Continue searching the parent directory? "))
 
 (defun helm-ag--set-command-feature ()
   (setq helm-ag--command-feature
-        (when (string-prefix-p "pt" helm-ag-base-command)
+        (when (or (string-prefix-p "rg" helm-ag-base-command) (string-prefix-p "pt" helm-ag-base-command))
           (if (string-match-p "-e" helm-ag-base-command)
               'pt-regexp
             'pt))))


### PR DESCRIPTION
ripgrep, like pt, does not support lookaheads.
because of this we should use the same pattern conversion as pt.

I also updated the note for pt users to include rg users.