### PR TITLE
Defun thing at point function

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -151,9 +151,9 @@ Default behaviour shows finish and result in mode-line."
       (push (list :buffer helm-current-buffer :point curpoint) helm-ag--context-stack))))
 
 (defun helm-ag--insert-thing-at-point (thing)
-    (helm-aif (thing-at-point thing)
-        (substring-no-properties it)
-      ""))
+  (helm-aif (thing-at-point thing)
+      (substring-no-properties it)
+    ""))
 
 (defun helm-ag--searched-word ()
   (if helm-ag-insert-at-point

--- a/helm-ag.el
+++ b/helm-ag.el
@@ -150,10 +150,10 @@ Default behaviour shows finish and result in mode-line."
         (push (list :file it :point curpoint) helm-ag--context-stack)
       (push (list :buffer helm-current-buffer :point curpoint) helm-ag--context-stack))))
 
-(defsubst helm-ag--insert-thing-at-point (thing)
-  (helm-aif (thing-at-point thing)
-      (substring-no-properties it)
-    ""))
+(defun helm-ag--insert-thing-at-point (thing)
+    (helm-aif (thing-at-point thing)
+        (substring-no-properties it)
+      ""))
 
 (defun helm-ag--searched-word ()
   (if helm-ag-insert-at-point


### PR DESCRIPTION
I'd like to hook a advice to `helm-ag--insert-thing-at-point`.
So, Could this function be defined using `defun`?
It seems no problem cause this function don't seem to be called frequenctly.