### PR TITLE
Set keymap in source definitions

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -456,6 +456,7 @@ Default behaviour shows finish and result in mode-line."
     :fuzzy-match helm-ag-fuzzy-match
     :action helm-ag--actions
     :candidate-number-limit 9999
+    :keymap helm-ag-map
     :follow (and helm-follow-mode-persistent 1)))
 
 ;;;###autoload
@@ -1044,6 +1045,7 @@ Continue searching the parent directory? "))
     :nohighlight t
     :requires-pattern 3
     :candidate-number-limit 9999
+    :keymap helm-do-ag-map
     :follow (and helm-follow-mode-persistent 1)))
 
 (defun helm-ag--do-ag-up-one-level ()


### PR DESCRIPTION
Keymap in helm-resume does not work without this.

This is related to https://github.com/emacs-helm/helm/issues/1678#event-938908476
CC: @it3ration