### PR TITLE
Check if ag executable exists on remote system

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -281,6 +281,8 @@ Default behaviour shows finish and result in mode-line."
             (unless (zerop ret)
               (unless (executable-find (car cmds))
                 (error "'ag' is not installed."))
+              (unless (file-exists-p (concat (file-remote-p default-directory) (executable-find (car cmds))))
+                (error "'ag' is not installed on remote system."))
               (error "Failed: '%s'" helm-ag--last-query))))
         (when helm-ag--buffer-search
           (helm-ag--abbreviate-file-name))


### PR DESCRIPTION
If you have `ag` installed locally and want to do `helm-ag` in a remote directory, `helm-ag.el` just says:

> failed: 'search term'

This PR tries to report missing remote executable.
